### PR TITLE
Add VS Code devcontainer to Pond

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,11 +13,11 @@ COPY pond /usr/local/bin/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends curl jq \
     && apt-get -y install ca-certificates curl python3-pip python3-dev python3-setuptools python3-wheel \
+    && pip install --upgrade pip && pip install requests \
     && sudo rm -rf /var/lib/apt/lists/*
+
+# RUN pond init --nodes 1
 
 RUN rustup update stable \
     && rustup target add wasm32-unknown-unknown
 
-RUN cargo install cargo-run-script cargo-tarpaulin
-
-# RUN pond init --nodes 1

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,8 +16,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && pip install --upgrade pip && pip install requests \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# RUN pond init --nodes 1
-
 RUN rustup update stable \
     && rustup target add wasm32-unknown-unknown
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+FROM cosmwasm/wasmd:v0.45.0 as wasmd
+
+FROM cosmwasm/rust-optimizer:0.45 as rust-optimizer
+
+FROM mcr.microsoft.com/devcontainers/rust:1-bullseye
+
+COPY --from=wasmd /usr/bin/wasmd /usr/local/bin/wasmd
+COPY --from=wasmd /opt/* /opt/
+
+COPY pond /usr/local/bin/
+
+# Install additional packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends curl jq \
+    && apt-get -y install ca-certificates curl python3-pip python3-dev python3-setuptools python3-wheel \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+RUN rustup update stable \
+    && rustup target add wasm32-unknown-unknown
+
+RUN cargo install cargo-run-script cargo-tarpaulin
+
+# RUN pond init --nodes 1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "Pond",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "build": {
+        // Path is relative to the devcontainer.json file.
+        "dockerfile": "Dockerfile",
+		"context": ".."
+    },
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/rust:1": {},
+		"ghcr.io/devcontainers/features/go:1": {},
+		"ghcr.io/devcontainers/features/node:1": {}
+	},
+	"postCreateCommand": "pond start"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,6 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/debian
 {
 	"name": "Pond",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
     "build": {
-        // Path is relative to the devcontainer.json file.
         "dockerfile": "Dockerfile",
 		"context": ".."
     },
@@ -14,17 +10,5 @@
 		"ghcr.io/devcontainers/features/go:1": {},
 		"ghcr.io/devcontainers/features/node:1": {}
 	},
-	"postCreateCommand": "pond start"
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+	"postCreateCommand": "pond init --nodes 1 && pond start"
 }

--- a/README.md
+++ b/README.md
@@ -35,3 +35,19 @@ pond stop
 ```bash
 pond info
 ```
+
+### Dev Containers
+
+To open the repository in a VS Code Devcontainer:
+- Use VS Code on your local machine
+- Install the [Dev Containers VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+- Click on the bottom left and choose to Reopen in Container
+
+[!WARNING]
+Do not use it in Github Codespaces as the Kujira apps will not see it at the required IP Addresses
+
+This will install:
+1. Pond
+2. Rust with cosmwasm and wasmd
+3. Node
+4. Go


### PR DESCRIPTION
Adds:
1. Rust
2. Node
3. Go
4. Pond Installed

Also updated README to include the instructions to use it in a VS Code devcontainer